### PR TITLE
Update check_http_json.py

### DIFF
--- a/check_http_json.py
+++ b/check_http_json.py
@@ -11,6 +11,8 @@ import httplib, urllib, urllib2
 import json
 import argparse
 from pprint import pprint
+from urllib2 import HTTPError
+from urllib2 import URLError
 
 
 class NagiosHelper:

--- a/check_http_json.py
+++ b/check_http_json.py
@@ -44,8 +44,8 @@ class JsonHelper:
 		self.data = json_data
 
 	def equals(self, key, value): return self.exists(key) and str(self.get(key)) == value
-	def lte(self, key, value): return self.exists(key) and str(self.get(key)) <= value
-	def gte(self, key, value): return self.exists(key) and str(self.get(key)) >= value
+	def lte(self, key, value): return self.exists(key) and float(self.get(key)) <= float(value)
+	def gte(self, key, value): return self.exists(key) and float(self.get(key)) >= float(value)
 	def exists(self, key): return (self.get(key) != (None, 'not_found'))
 	def get(self, key, temp_data=''):
 		"""Can navigate nested json keys with a dot format (Element.Key.NestedKey). Returns (None, 'not_found') if not found"""


### PR DESCRIPTION
casting compared values to floats instead of strings. String comparison uses lexicographical ordering: https://docs.python.org/2/tutorial/datastructures.html#comparing-sequences-and-other-types. It could cause unexpected behaviours.