### PR TITLE
Added default User-Agent header

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Executing `./check_http_json.py -h` will yield the following details:
 
 ```
 usage: check_http_json.py [-h] [-d] [-s] -H HOST [-P PORT] [-p PATH]
-                          [-t TIMEOUT] [-B AUTH] [-D DATA] [-A HEADERS]
+                          [-t TIMEOUT] [-B AUTH] [-D DATA] [-A HEADERS] [-I]
                           [-f SEPARATOR]
                           [-w [KEY_THRESHOLD_WARNING [KEY_THRESHOLD_WARNING ...]]]
                           [-c [KEY_THRESHOLD_CRITICAL [KEY_THRESHOLD_CRITICAL ...]]]
@@ -44,6 +44,7 @@ optional arguments:
   -D DATA, --data DATA  The http payload to send as a POST
   -A HEADERS, --headers HEADERS
                         The http headers in JSON format.
+  -I, --insecure        Do not validate certificates
   -f SEPARATOR, --field_separator SEPARATOR
                         Json Field separator, defaults to "." ; Select element
                         in an array with "(" ")"
@@ -81,6 +82,7 @@ optional arguments:
                         formats for this parameter are: (key[>alias]),
                         (key[>alias],UnitOfMeasure),
                         (key[>alias],UnitOfMeasure,WarnRange,CriticalRange).
+
 ```
 
 ## Examples

--- a/check_http_json.py
+++ b/check_http_json.py
@@ -407,6 +407,7 @@ if __name__ == "__main__":
 	# Attempt to reach the endpoint
 	try:
 		req = urllib2.Request(url)
+		req.add_header("User-Agent", "nagios-http-json")
 		if args.auth:
 			base64str = base64.encodestring(args.auth).replace('\n', '')
 			req.add_header('Authorization', 'Basic %s' % base64str)


### PR DESCRIPTION
Hi,
thank you for creating this check. I have a tiny addition because i think it is useful to have a default User-Agent header. The reasons are:
- prevent errors for services which require this header (like Cloudflare WAF) 
- save time by not needing to defining the header 
- save more time by not needing to find out why services (like Cloudflare WAF) are blocking your requests
- and to follow the [rfc7231 recommendations](https://tools.ietf.org/html/rfc7231#section-5.5.3): "A user agent SHOULD send a User-Agent field in each request unless specifically configured not to do so.”
