### PR TITLE
Parse JSON if HTTPError is greater than 500

### DIFF
--- a/check_http_json.py
+++ b/check_http_json.py
@@ -22,7 +22,6 @@ OK_CODE = 0
 WARNING_CODE = 1
 CRITICAL_CODE = 2
 UNKNOWN_CODE = 3
-value_tested = 0
 
 class NagiosHelper:
     """Help with Nagios specific status string formatting."""


### PR DESCRIPTION
Sometimes a JSON API can return errors with HTTP error code 502 like this : {"database":{"msg":"database is up-to-date","success":true},"registry":{"msg":"registry is reachable","success":true},"clair":{"msg":"clair is not reachable: Failed to open TCP connection to clair:6061 (getaddrinfo: Name or service not known)","success":false}}

I had added in check_http_json.py the possibility of parse JSON response with -w -c -e -E -q -Q -m options when HTTP error code is greater than 500 (if no options is set, the script return: UNKNOWN: Status UNKNOWN.HTTPError[503]