### PR TITLE
Add value_separator option to specify how JSON values are being split 

### DIFF
--- a/check_http_json.py
+++ b/check_http_json.py
@@ -88,9 +88,10 @@ class JsonHelper:
     JSON dict
     """
 
-    def __init__(self, json_data, separator):
+    def __init__(self, json_data, separator, value_separator):
         self.data = json_data
         self.separator = separator
+        self.value_separator = value_separator
         self.arrayOpener = '('
         self.arrayCloser = ')'
 
@@ -126,7 +127,7 @@ class JsonHelper:
 
     def equals(self, key, value):
         return self.exists(key) and \
-            str(self.get(key)) in value.split(':')
+            str(self.get(key)) in value.split(self.value_separator)
 
     def lte(self, key, value):
         return self.exists(key) and float(self.get(key)) <= float(value)
@@ -216,11 +217,15 @@ class JsonRuleProcessor:
         self.data = json_data
         self.rules = rules_args
         separator = '.'
+        value_separator = ':'
         if self.rules.separator:
             separator = self.rules.separator
-        self.helper = JsonHelper(self.data, separator)
+        if self.rules.value_separator:
+            value_separator = self.rules.value_separator
+        self.helper = JsonHelper(self.data, separator, value_separator)
         debugPrint(rules_args.debug, "rules:%s" % rules_args)
         debugPrint(rules_args.debug, "separator:%s" % separator)
+        debugPrint(rules_args.debug, "value_separator:%s" % value_separator)
         self.metric_list = self.expandKeys(self.rules.metric_list)
         self.key_threshold_warning = self.expandKeys(
             self.rules.key_threshold_warning)
@@ -442,6 +447,8 @@ def parseArgs(args):
     parser.add_argument('-f', '--field_separator', dest='separator',
                         help='''JSON Field separator, defaults to ".";
                         Select element in an array with "(" ")"''')
+    parser.add_argument('-F', '--value_separator', dest='value_separator',
+                        help='''JSON Value separator, defaults to ":"''')
     parser.add_argument('-w', '--warning', dest='key_threshold_warning',
                         nargs='*',
                         help='''Warning threshold for these values

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -27,3 +27,8 @@ class ArgsTest(unittest.TestCase):
     def test_parser_with_port(self):
         parser = parseArgs(['-H', 'foobar', '-P', '8888'])
         self.assertEqual(parser.port, '8888')
+
+    def test_parser_with_separator(self):
+        parser = parseArgs(['-H', 'foobar', '-f', '_', '-F', '_'])
+        self.assertEqual(parser.separator, '_')
+        self.assertEqual(parser.value_separator, '_')

--- a/test/test_check_http_json.py
+++ b/test/test_check_http_json.py
@@ -19,6 +19,7 @@ UNKNOWN_CODE = 3
 
 class RulesHelper:
     separator = '.'
+    value_separator = ':'
     debug = False
     key_threshold_warning = None
     key_value_list = None
@@ -122,6 +123,17 @@ class UtilTest(unittest.TestCase):
                         '{"metric": 5}', CRITICAL_CODE)
         self.check_data(RulesHelper().dash_q(['metric,5']),
                         '{"metric": 5}', OK_CODE)
+
+    def test_equality_colon(self):
+        """
+        See https://github.com/drewkerrigan/nagios-http-json/issues/43
+        """
+        rules = RulesHelper()
+        rules.value_separator = '_'
+
+        # This should not fail
+        self.check_data(rules.dash_q(['metric,foo:bar']),
+                        '{"metric": "foo:bar"}', OK_CODE)
 
     def test_non_equality(self):
         self.check_data(RulesHelper().dash_y(['metric,6']),


### PR DESCRIPTION
 - Used -F since it's similar to -f 
 - Default value remains `:` to ensure backwards compatibility
 - Fixes #43 