### PR TITLE
Fix new Python3.8 warnings:

### DIFF
--- a/check_http_json.py
+++ b/check_http_json.py
@@ -183,10 +183,10 @@ class JsonHelper:
             subElemKey = key[:key.find('(*)')-1]
         remainingKey = key[key.find('(*)')+3:]
         elemData = self.get(subElemKey)
-        if elemData is (None, 'not_found'):
+        if elemData == (None, 'not_found'):
             keys.append(key)
             return keys
-        if subElemKey is not '':
+        if subElemKey != '':
             subElemKey = subElemKey + '.'
         for i in range(len(elemData)):
             newKey = subElemKey + '(' + str(i) + ')' + remainingKey


### PR DESCRIPTION
```
./check_http_json.py:186: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if elemData is (None, 'not_found'):
./check_http_json.py:189: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if subElemKey is not '':
```