### PR TITLE
[TLS] Always load system default C.A files

### DIFF
--- a/check_http_json.py
+++ b/check_http_json.py
@@ -550,6 +550,7 @@ def main(cliargs):
             context.verify_mode = ssl.CERT_NONE
         else:
             context.verify_mode = ssl.CERT_OPTIONAL
+            context.load_default_certs()
             if args.cacert:
                 try:
                     context.load_verify_locations(args.cacert)


### PR DESCRIPTION
If TLS is enabled, context now loads the system default C.A files

This allows system wide deployed C.A to be used without any further configuration or use of the `--cacert` parameter.