### PR TITLE
fix missing type conversion for --data

### DIFF
--- a/check_http_json.py
+++ b/check_http_json.py
@@ -599,13 +599,15 @@ def main(cliargs):
             for header in headers:
                 req.add_header(header, headers[header])
         if args.timeout and args.data:
+            databytes = str(args.data).encode()
             response = urllib.request.urlopen(req, timeout=args.timeout,
-                                              data=args.data, context=context)
+                                              data=databytes, context=context)
         elif args.timeout:
             response = urllib.request.urlopen(req, timeout=args.timeout,
                                               context=context)
         elif args.data:
-            response = urllib.request.urlopen(req, data=args.data, context=context)
+            databytes = str(args.data).encode()
+            response = urllib.request.urlopen(req, data=databytes, context=context)
         else:
             response = urllib.request.urlopen(req, context=context)
 


### PR DESCRIPTION
The parameter --data is handled as type string, but the method urlopen() only accepts the datatype byte.
Before this fix you will get: "TypeError: POST data should be  bytes, an iterable of bytes, or a filer object. It cannot be of type str."
This PR solves this.