### PR TITLE
Add CLI Flag to change HTTP method

### DIFF
--- a/check_http_json.py
+++ b/check_http_json.py
@@ -430,6 +430,8 @@ def parseArgs(args):
                         help='remote host to query')
     parser.add_argument('-k', '--insecure', action='store_true',
                         help='do not check server SSL certificate')
+    parser.add_argument('-X', '--request', dest='method', default='GET', choices=['GET', 'POST'],
+                        help='Specifies a custom request method to use when communicating  with  the HTTP server')
     parser.add_argument('-V', '--version', action='store_true',
                         help='print version of this plugin')
     parser.add_argument('--cacert',
@@ -587,7 +589,7 @@ def main(cliargs):
     json_data = ''
 
     try:
-        req = urllib.request.Request(url)
+        req = urllib.request.Request(url, method=args.method)
         req.add_header("User-Agent", "check_http_json")
         if args.auth:
             authbytes = str(args.auth).encode()

--- a/check_http_json.py
+++ b/check_http_json.py
@@ -542,7 +542,7 @@ def main(cliargs):
     if args.ssl:
         url = "https://%s" % args.host
 
-        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         context.options |= ssl.OP_NO_SSLv2
         context.options |= ssl.OP_NO_SSLv3
 


### PR DESCRIPTION
Fixes #70 

Example

```
/check_http_json.py -H 127.0.0.1:5000 -p postme -E "examples.(0).capacity" 
UNKNOWN: Status UNKNOWN. HTTPError[405], url:http://127.0.0.1:5000/postme Parser error: Expecting value: line 1 column 1 (char 0)

check_http_json.py -X POST -H 127.0.0.1:5000 -p postme -E "examples.(0).capacity"
OK: Status OK.

```