### PR TITLE
disabled check_hostname to prevent error message when setting CERT_NONE

### DIFF
--- a/check_http_json.py
+++ b/check_http_json.py
@@ -549,6 +549,7 @@ def main(cliargs):
         context.options |= ssl.OP_NO_SSLv3
 
         if args.insecure:
+            context.check_hostname = False
             context.verify_mode = ssl.CERT_NONE
         else:
             context.verify_mode = ssl.CERT_OPTIONAL


### PR DESCRIPTION
We encountered error message on some urllib versions. This can be fixed when setting check_hostname to False before CERT_NONE is applied. Documentation in urllib: [https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname)
In my opinion this is no security drawback as CERT_NONE is already a "statement" regarding security ;-)

```
Traceback (most recent call last):
  File "check_http_json.py", line 650, in <module>
    main(sys.argv[1:])
  File "check_http_json.py", line 552, in main
    context.verify_mode = ssl.CERT_NONE
  File "/usr/lib64/python3.6/ssl.py", line 443, in verify_mode
    super(SSLContext, SSLContext).verify_mode.__set__(self, value)
ValueError: Cannot set verify_mode to CERT_NONE when check_hostname is enabled.

```
