### PR TITLE
Handle socket errors

### DIFF
--- a/check_http_json.py
+++ b/check_http_json.py
@@ -6,6 +6,7 @@ import json
 import argparse
 import sys
 import ssl
+import socket
 import traceback
 from urllib.error import HTTPError
 from urllib.error import URLError
@@ -683,21 +684,29 @@ def make_request(args, url, context):
         debugPrint(args.debug, "Headers:\n %s" % headers)
         for header in headers:
             req.add_header(header, headers[header])
-    if args.timeout and args.data:
-        databytes = str(args.data).encode()
-        response = urllib.request.urlopen(req, timeout=args.timeout,
-                                          data=databytes, context=context)
-    elif args.timeout:
-        response = urllib.request.urlopen(req, timeout=args.timeout,
-                                          context=context)
-    elif args.data:
-        databytes = str(args.data).encode()
-        response = urllib.request.urlopen(req, data=databytes, context=context)
-    else:
-        # pylint: disable=consider-using-with
-        response = urllib.request.urlopen(req, context=context)
 
-    return response.read()
+    try:
+        if args.timeout and args.data:
+            databytes = str(args.data).encode()
+            response = urllib.request.urlopen(req, timeout=args.timeout,
+                                              data=databytes, context=context)
+        elif args.timeout:
+            response = urllib.request.urlopen(req, timeout=args.timeout,
+                                              context=context)
+        elif args.data:
+            databytes = str(args.data).encode()
+            response = urllib.request.urlopen(req, data=databytes, context=context)
+        else:
+            # pylint: disable=consider-using-with
+            response = urllib.request.urlopen(req, context=context)
+    
+        return response.read()
+
+    except socket.timeout:
+        nagios = NagiosHelper()
+        nagios.append_message(args.unreachable_state, " Socket timeout after %ss | %s" % (args.timeout or 'default', url))
+        print(nagios.getMessage())
+        sys.exit(nagios.getCode())
 
 
 def main(cliargs):

--- a/check_http_json.py
+++ b/check_http_json.py
@@ -699,7 +699,7 @@ def make_request(args, url, context):
         else:
             # pylint: disable=consider-using-with
             response = urllib.request.urlopen(req, context=context)
-    
+
         return response.read()
 
     except socket.timeout:


### PR DESCRIPTION
Hello,

this PR aims to handle socket errors, which currently produce stacktraces in the plugin output.

before:
```
Traceback (most recent call last):
  File "/usr/lib64/nagios/plugins/check_http_json.py", line 772, in <module>
    main(sys.argv[1:])
  File "/usr/lib64/nagios/plugins/check_http_json.py", line 727, in main
    json_data = make_request(args, url, context)
  File "/usr/lib64/nagios/plugins/check_http_json.py", line 687, in make_request
    response = urllib.request.urlopen(req, timeout=args.timeout,
  File "/usr/lib64/python3.9/urllib/request.py", line 214, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python3.9/urllib/request.py", line 517, in open
    response = self._open(req, data)
  File "/usr/lib64/python3.9/urllib/request.py", line 534, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/usr/lib64/python3.9/urllib/request.py", line 494, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.9/urllib/request.py", line 1389, in https_open
    return self.do_open(http.client.HTTPSConnection, req,
  File "/usr/lib64/python3.9/urllib/request.py", line 1350, in do_open
    r = h.getresponse()
  File "/usr/lib64/python3.9/http/client.py", line 1377, in getresponse
    response.begin()
  File "/usr/lib64/python3.9/http/client.py", line 320, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python3.9/http/client.py", line 281, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib64/python3.9/socket.py", line 716, in readinto
    return self._sock.recv_into(b)
  File "/usr/lib64/python3.9/ssl.py", line 1277, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/lib64/python3.9/ssl.py", line 1135, in read
    return self._sslobj.read(len, buffer)
socket.timeout: The read operation timed out
```

after:
```
UNKNOWN: Status UNKNOWN. Socket timeout after 10s | https://<target_url>
```